### PR TITLE
Check if accessToken is in record

### DIFF
--- a/http/middleware/HasBearerToken.php
+++ b/http/middleware/HasBearerToken.php
@@ -71,6 +71,6 @@ class HasBearerToken
             return false;
         }
 
-        return $accessToken->created_at->gt(now()->subMinutes($this->expiration));
+        return (($accessToken && !$this->expiration) || $accessToken->created_at->gt(now()->subMinutes($this->expiration)));
     }
 }


### PR DESCRIPTION
You can make long running tokens that don't expire in sanctum, this should check for it as long as the token exists and the expires field is empty